### PR TITLE
Do not require Python "3.6"

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,3 @@ pytest = "*"
 
 [packages]
 e1839a8 = {editable = true,path = "."}
-
-[requires]
-python_version = "3.6"


### PR DESCRIPTION
Closes: https://github.com/CodeChain-io/codechain-sdk-python/issues/20