### PR TITLE
Use dataclass

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,3 +8,4 @@ codechain = {editable = true,path = "."}
 pytest = "*"
 
 [packages]
+dataclasses = {markers = "python_version < '3.7'",version = "*"}

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+codechain = {editable = true,path = "."}
 pytest = "*"
 
 [packages]
-codechain = {editable = true,path = "."}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ed0daa90494a898855074efc0d24d0ef63638212ead294a76509bac8c26418a0"
+            "sha256": "f43dc511136f24827ca4d00b4e132b1a58faecdd9e16da04a7e341d2655e9f5b"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -13,46 +13,63 @@
             }
         ]
     },
-    "default": {
+    "default": {},
+    "develop": {
         "asn1crypto": {
             "hashes": [
-                "sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87",
-                "sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"
+                "sha256:7bb1cc02a5620b3d72da4ba070bda2f44f0e61b44dee910a302eddff802b6fb5",
+                "sha256:87620880a477123e01177a1f73d0f327210b43a3cdbd714efcd2fa49a8d7b384"
             ],
-            "version": "==0.24.0"
+            "version": "==1.2.0"
+        },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+            ],
+            "version": "==1.3.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
         },
         "cffi": {
             "hashes": [
-                "sha256:041c81822e9f84b1d9c401182e174996f0bae9991f33725d059b771744290774",
-                "sha256:046ef9a22f5d3eed06334d01b1e836977eeef500d9b78e9ef693f9380ad0b83d",
-                "sha256:066bc4c7895c91812eff46f4b1c285220947d4aa46fa0a2651ff85f2afae9c90",
-                "sha256:066c7ff148ae33040c01058662d6752fd73fbc8e64787229ea8498c7d7f4041b",
-                "sha256:2444d0c61f03dcd26dbf7600cf64354376ee579acad77aef459e34efcb438c63",
-                "sha256:300832850b8f7967e278870c5d51e3819b9aad8f0a2c8dbe39ab11f119237f45",
-                "sha256:34c77afe85b6b9e967bd8154e3855e847b70ca42043db6ad17f26899a3df1b25",
-                "sha256:46de5fa00f7ac09f020729148ff632819649b3e05a007d286242c4882f7b1dc3",
-                "sha256:4aa8ee7ba27c472d429b980c51e714a24f47ca296d53f4d7868075b175866f4b",
-                "sha256:4d0004eb4351e35ed950c14c11e734182591465a33e960a4ab5e8d4f04d72647",
-                "sha256:4e3d3f31a1e202b0f5a35ba3bc4eb41e2fc2b11c1eff38b362de710bcffb5016",
-                "sha256:50bec6d35e6b1aaeb17f7c4e2b9374ebf95a8975d57863546fa83e8d31bdb8c4",
-                "sha256:55cad9a6df1e2a1d62063f79d0881a414a906a6962bc160ac968cc03ed3efcfb",
-                "sha256:5662ad4e4e84f1eaa8efce5da695c5d2e229c563f9d5ce5b0113f71321bcf753",
-                "sha256:59b4dc008f98fc6ee2bb4fd7fc786a8d70000d058c2bbe2698275bc53a8d3fa7",
-                "sha256:73e1ffefe05e4ccd7bcea61af76f36077b914f92b76f95ccf00b0c1b9186f3f9",
-                "sha256:a1f0fd46eba2d71ce1589f7e50a9e2ffaeb739fb2c11e8192aa2b45d5f6cc41f",
-                "sha256:a2e85dc204556657661051ff4bab75a84e968669765c8a2cd425918699c3d0e8",
-                "sha256:a5457d47dfff24882a21492e5815f891c0ca35fefae8aa742c6c263dac16ef1f",
-                "sha256:a8dccd61d52a8dae4a825cdbb7735da530179fea472903eb871a5513b5abbfdc",
-                "sha256:ae61af521ed676cf16ae94f30fe202781a38d7178b6b4ab622e4eec8cefaff42",
-                "sha256:b012a5edb48288f77a63dba0840c92d0504aa215612da4541b7b42d849bc83a3",
-                "sha256:d2c5cfa536227f57f97c92ac30c8109688ace8fa4ac086d19d0af47d134e2909",
-                "sha256:d42b5796e20aacc9d15e66befb7a345454eef794fdb0737d1af593447c6c8f45",
-                "sha256:dee54f5d30d775f525894d67b1495625dd9322945e7fee00731952e0368ff42d",
-                "sha256:e070535507bd6aa07124258171be2ee8dfc19119c28ca94c9dfb7efd23564512",
-                "sha256:e1ff2748c84d97b065cc95429814cdba39bcbd77c9c85c89344b317dc0d9cbff",
-                "sha256:ed851c75d1e0e043cbf5ca9a8e1b13c4c90f3fbd863dacb01c0808e2b5204201"
+                "sha256:00d890313797d9fe4420506613384b43099ad7d2b905c0752dbcc3a6f14d80fa",
+                "sha256:0cf9e550ac6c5e57b713437e2f4ac2d7fd0cd10336525a27224f5fc1ec2ee59a",
+                "sha256:0ea23c9c0cdd6778146a50d867d6405693ac3b80a68829966c98dd5e1bbae400",
+                "sha256:193697c2918ecdb3865acf6557cddf5076bb39f1f654975e087b67efdff83365",
+                "sha256:1ae14b542bf3b35e5229439c35653d2ef7d8316c1fffb980f9b7647e544baa98",
+                "sha256:1e389e069450609c6ffa37f21f40cce36f9be7643bbe5051ab1de99d5a779526",
+                "sha256:263242b6ace7f9cd4ea401428d2d45066b49a700852334fd55311bde36dcda14",
+                "sha256:33142ae9807665fa6511cfa9857132b2c3ee6ddffb012b3f0933fc11e1e830d5",
+                "sha256:364f8404034ae1b232335d8c7f7b57deac566f148f7222cef78cf8ae28ef764e",
+                "sha256:47368f69fe6529f8f49a5d146ddee713fc9057e31d61e8b6dc86a6a5e38cecc1",
+                "sha256:4895640844f17bec32943995dc8c96989226974dfeb9dd121cc45d36e0d0c434",
+                "sha256:558b3afef987cf4b17abd849e7bedf64ee12b28175d564d05b628a0f9355599b",
+                "sha256:5ba86e1d80d458b338bda676fd9f9d68cb4e7a03819632969cf6d46b01a26730",
+                "sha256:63424daa6955e6b4c70dc2755897f5be1d719eabe71b2625948b222775ed5c43",
+                "sha256:6381a7d8b1ebd0bc27c3bc85bc1bfadbb6e6f756b4d4db0aa1425c3719ba26b4",
+                "sha256:6381ab708158c4e1639da1f2a7679a9bbe3e5a776fc6d1fd808076f0e3145331",
+                "sha256:6fd58366747debfa5e6163ada468a90788411f10c92597d3b0a912d07e580c36",
+                "sha256:728ec653964655d65408949b07f9b2219df78badd601d6c49e28d604efe40599",
+                "sha256:7cfcfda59ef1f95b9f729c56fe8a4041899f96b72685d36ef16a3440a0f85da8",
+                "sha256:819f8d5197c2684524637f940445c06e003c4a541f9983fd30d6deaa2a5487d8",
+                "sha256:825ecffd9574557590e3225560a8a9d751f6ffe4a49e3c40918c9969b93395fa",
+                "sha256:9009e917d8f5ef780c2626e29b6bc126f4cb2a4d43ca67aa2b40f2a5d6385e78",
+                "sha256:9c77564a51d4d914ed5af096cd9843d90c45b784b511723bd46a8a9d09cf16fc",
+                "sha256:a19089fa74ed19c4fe96502a291cfdb89223a9705b1d73b3005df4256976142e",
+                "sha256:a40ed527bffa2b7ebe07acc5a3f782da072e262ca994b4f2085100b5a444bbb2",
+                "sha256:bb75ba21d5716abc41af16eac1145ab2e471deedde1f22c6f99bd9f995504df0",
+                "sha256:e22a00c0c81ffcecaf07c2bfb3672fa372c50e2bd1024ffee0da191c1b27fc71",
+                "sha256:e55b5a746fb77f10c83e8af081979351722f6ea48facea79d470b3731c7b2891",
+                "sha256:ec2fa3ee81707a5232bf2dfbd6623fdb278e070d596effc7e2d788f2ada71a05",
+                "sha256:fd82eb4694be712fcae03c717ca2e0fc720657ac226b80bbb597e971fc6928c2"
             ],
-            "version": "==1.12.3"
+            "version": "==1.13.1"
         },
         "codechain": {
             "editable": true,
@@ -60,32 +77,35 @@
         },
         "coincurve": {
             "hashes": [
-                "sha256:01b1dad52c718c694dec1881bcda28358cd672c2a800c791b293ac60ce378e4d",
-                "sha256:023a32800b76fbbc070d79fb028910789a5cb52813bbd809ae134965ceec26fc",
-                "sha256:0eeaa5dc061c9341fc4802421e036a705edfe6487b71d41b3045f6532cc13c8f",
-                "sha256:16697fd18874ca3d7a0b452f022a2604cab08af0b8326dda83da868e85ee6ecc",
-                "sha256:174d7fe9c886abf77131724d4eb1816ca99c6a876b02ea4382a8fc638c5c5659",
-                "sha256:42bf66b273220eaf5cc20fe868bc544931c76a09716121b8f93b4ba639b9c1ff",
-                "sha256:4ddb162249cbf54952b424aa3a0c97549893597c9d4529589bd9a89969151042",
-                "sha256:5885e4d7c05707db460a2cdec3ca08bf7dec185514eb7fa0417ea2c7e686804e",
-                "sha256:6a4f721937a1bced6381130a34c9b5da2e7041973f2aa5e78bb64889d8663658",
-                "sha256:6d5cf56de0adebcf7f2395b279868b19fee17a98b7de2c8c38f4b15b3b0805b5",
-                "sha256:750476ff4eddb44902dbbb3b311ecfb62071327e38dbe0c833bee435e4007f57",
-                "sha256:7e04c83d3d977df6caad688a66b98eb87d3b0d70a4a698c7339abc5bc818aba1",
-                "sha256:7e6685a2bd59bbbfe7d21fcca036f045b88ada209b257c5f4edb976379d9ba8a",
-                "sha256:901009df491ff042e666f0b1afa9b40ffd9db0608be7ced4f5572e068d933dbb",
-                "sha256:a8e29373eb53214e7f3e9bbc819bc2b700bf1e599f357157737fe12e97938dbe",
-                "sha256:bce55e69056d5c4b645e0dfad57c8d9c46de851b8b2d11c6a539655221d04dba",
-                "sha256:c118b85ee107d9be1e34645f94be505882bcf2616bd09ddf4ef2d207f9f5e82f",
-                "sha256:e01c7b9c705ea377ac18c7ec6a1cebd545204e844209c985e23059bf5de58ca9",
-                "sha256:e1300fc144e28cb825deeaa44cb0475455437b9aa7dbcafcf46ed083a10670f8",
-                "sha256:e3f63cbc4b7cb0b70845bb1f9f4b714822bd3a1a68db4a90f325f7cce1daed77",
-                "sha256:e76172a97e693e96f165435640f7a5e55f1c3005e602b25d10875ee0c3014b57",
-                "sha256:e851630985a0f0b099d1ed3bdf2c50a68b4aa4c2dc31fa53a1a6a7dbb76ee554",
-                "sha256:ea0b7150053a8c46d0f2096ec75a6f7cdcbd4afd1abafa0caa28f3cdd34e3987",
-                "sha256:f79d168089756058953593e06f8c3f3aa044d07fe440c142753e58895a0077a2"
+                "sha256:0da923e7eba89d65ff37d18be4935d710f21032f645e59f0b0749f40c19807d9",
+                "sha256:1be6b876bfbdfdd8c4e94708c9cd024cb06c8461cabbcd9b96659743a23dfbd6",
+                "sha256:1e3b9068df66df8669b4e58e03c5e95f382e582cf31a743c9aae9963272482bc",
+                "sha256:1f6d74500eb5ba1bf3a8e2ac3c7bcc96d7076082a3b5500fa63f4b8fad170b75",
+                "sha256:2d540d79adfca1c5be0122362b87ad7308b77a517da9dc51e523b7fbe8ac405a",
+                "sha256:4595c6bfb5be36a7365c638f535b10afffe7bea70eff3b57e8c3cb5e7eaf5325",
+                "sha256:4c1d9241a31c0fe6d50ce561294f63955ec0fb3afbf1579da8b3742612a6e9dc",
+                "sha256:546fc4765e38aa36a723e8ebca03408145c4837d470bd3704e295902ee4e4224",
+                "sha256:6eaf8ef5d91f6ebc2df35b7fce958b33fbee581f0e0becedfcbb8947da1764e8",
+                "sha256:75a6a7c6116d7f10992e06c0aeeaddcaee55a537ceef17961180ba8dd33e4a03",
+                "sha256:800b649bfc8e12a49927c98f02bfcc543af80f06bd25c4e5df41531ed142c681",
+                "sha256:8474d1576d06d9d0c210bd64e3e245e43a8ff6e18c90e343567c5954b088726e",
+                "sha256:96c023d330120a62234638b563f83d3064bfeb2d8a20ccbcf00ab4d851424458",
+                "sha256:9985627dc0c81fe98c3d2e97412801e9726d6110249317a2775cf365f0ba0df5",
+                "sha256:9af82dd36721245416c32256c0a3504dc13ee07de29b09ebb9724c2684b2cfb6",
+                "sha256:9e25ab16935d348be05bdf8fab648475e568a1b5754f518979c8e2cd08c4a71d",
+                "sha256:a01b2769c1045a8ba60bef61ef15c3b6276dcb75b850cfc0bfab92a2856deb3c",
+                "sha256:a769882d0e2bf5f21d54992794d78325021eabcc6bfc3d373aa1ad7760a0f7fe",
+                "sha256:b44eb772f696455ffc60e37c1b7de8ba4db9a388ddadfb960e6caf0f0da6b511",
+                "sha256:b7f901083695dee84ab7b1a34c90d00fb18b71db74d25fae5be10455016049a7",
+                "sha256:bec315f32b09bb14b3261a50c0decf4d3f51dcf5de9d6cfeaf463c37656f0087",
+                "sha256:c26546176bdc1a77321d38a0178544f5f12f41c8b47e227581adebd61f30dea5",
+                "sha256:e3ebedd738135b0661821c9d69369ee009adb87b21a32599fff7f78589d5e58d",
+                "sha256:e6e35e3cbb6872f51c3b869a4fa27f36dc760db268818084a879c47e5a5b69e4",
+                "sha256:f0b5cce8e677c493475cbe4356e4500e287d5f484918483f402bbd4305659af2",
+                "sha256:f136c98b4a2df3829e1f2f2e6a28f7ff9d5676c5c3614c6d3e511f07e024c093",
+                "sha256:fa4b6e311d45995012d194569a02281448d700681d72857433e05821a75d310d"
             ],
-            "version": "==12.0.0"
+            "version": "==13.0.0"
         },
         "cytoolz": {
             "hashes": [
@@ -114,41 +134,6 @@
                 "sha256:e874aa50ceeceb9e46d8a9cb566d2c010702b35eecde1c6b48c91c29e9d155d1"
             ],
             "version": "==1.7.0"
-        },
-        "pycparser": {
-            "hashes": [
-                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
-            ],
-            "version": "==2.19"
-        },
-        "rlp": {
-            "hashes": [
-                "sha256:0505fd53278cb4a3ea6baf1b658357ac209bdcdd1b316ac90050c40f669ceacc",
-                "sha256:ebe80a03c50e3d6aac47f44ddd45048bb99e411203cd764f5da1330e6d83821c"
-            ],
-            "version": "==1.1.0"
-        },
-        "toolz": {
-            "hashes": [
-                "sha256:08fdd5ef7c96480ad11c12d472de21acd32359996f69a5259299b540feba4560"
-            ],
-            "version": "==0.10.0"
-        }
-    },
-    "develop": {
-        "atomicwrites": {
-            "hashes": [
-                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
-                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
-            ],
-            "version": "==1.3.0"
-        },
-        "attrs": {
-            "hashes": [
-                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
-                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
-            ],
-            "version": "==19.1.0"
         },
         "importlib-metadata": {
             "hashes": [
@@ -186,6 +171,12 @@
             ],
             "version": "==1.8.0"
         },
+        "pycparser": {
+            "hashes": [
+                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+            ],
+            "version": "==2.19"
+        },
         "pyparsing": {
             "hashes": [
                 "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
@@ -195,11 +186,18 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:813b99704b22c7d377bbd756ebe56c35252bb710937b46f207100e843440b3c2",
-                "sha256:cc6620b96bc667a0c8d4fa592a8c9c94178a1bd6cc799dbb057dfd9286d31a31"
+                "sha256:7e4800063ccfc306a53c461442526c5571e1462f61583506ce97e4da6a1d88c8",
+                "sha256:ca563435f4941d0cb34767301c27bc65c510cb82e90b9ecf9cb52dc2c63caaa0"
             ],
             "index": "pypi",
-            "version": "==5.1.3"
+            "version": "==5.2.1"
+        },
+        "rlp": {
+            "hashes": [
+                "sha256:0505fd53278cb4a3ea6baf1b658357ac209bdcdd1b316ac90050c40f669ceacc",
+                "sha256:ebe80a03c50e3d6aac47f44ddd45048bb99e411203cd764f5da1330e6d83821c"
+            ],
+            "version": "==1.1.0"
         },
         "six": {
             "hashes": [
@@ -207,6 +205,12 @@
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
+        },
+        "toolz": {
+            "hashes": [
+                "sha256:08fdd5ef7c96480ad11c12d472de21acd32359996f69a5259299b540feba4560"
+            ],
+            "version": "==0.10.0"
         },
         "wcwidth": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f43dc511136f24827ca4d00b4e132b1a58faecdd9e16da04a7e341d2655e9f5b"
+            "sha256": "9bd56c4ff789a49326960a84f5db4ec62db57d6d93d1b67c08c5fbb6761e49ce"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -13,7 +13,17 @@
             }
         ]
     },
-    "default": {},
+    "default": {
+        "dataclasses": {
+            "hashes": [
+                "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f",
+                "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"
+            ],
+            "index": "pypi",
+            "markers": "python_version < '3.7'",
+            "version": "==0.6"
+        }
+    },
     "develop": {
         "asn1crypto": {
             "hashes": [

--- a/codechain/primitives/AssetAddress.py
+++ b/codechain/primitives/AssetAddress.py
@@ -1,7 +1,6 @@
 import re
+from dataclasses import dataclass
 from typing import List
-from typing import NamedTuple
-from typing import Tuple
 from typing import Union
 
 from ..crypto import bech32_decode
@@ -9,7 +8,8 @@ from ..crypto import bech32_encode
 from .HexString import H160
 
 
-class MultiSig(NamedTuple):
+@dataclass
+class MultiSig:
     n: int
     m: int
     pubkeys: List[H160]

--- a/codechain/primitives/PlatformAddress.py
+++ b/codechain/primitives/PlatformAddress.py
@@ -1,5 +1,5 @@
 import re
-import typing
+from dataclasses import dataclass
 
 from ..crypto import bech32_decode
 from ..crypto import bech32_encode
@@ -8,7 +8,8 @@ from .HexString import H160
 from .HexString import H512
 
 
-class PlatformAddress(typing.NamedTuple):
+@dataclass
+class PlatformAddress:
     account_id: H160
     value: str
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(
 with io.open("README.md", "rt", encoding="utf8") as f:
     readme = f.read()
 
-requires = ["rlp", "coincurve"]
+requires = ["rlp", "coincurve", "dataclasses; python_version < '3.7'"]
 
 setup(
     name=about["__title__"],


### PR DESCRIPTION
Depends on: https://github.com/CodeChain-io/codechain-sdk-python/pull/30

`dataclass` is better than `NamedTuple`
* You can override `def __init__()` and other methods
* It doesn't use a `metaclass`, so you can bring your own metaclass.
* It has a charming `.asdict()` that converts recursively as opposed to ugly `namedtuple._asdict()` that doesn't recurse.
* PyCharm doesn't complain that default items (statics) should be at the bottom of the definitions (False negative) when you want to add static variables (which is not default items).