### PR TITLE
Change default_language_version to 3.7

### DIFF
--- a/.pre-commit-config-ci.yaml
+++ b/.pre-commit-config-ci.yaml
@@ -1,9 +1,10 @@
+default_language_version:
+  python: python3.7
 repos:
   - repo: https://github.com/ambv/black
     rev: stable
     hooks:
     - id: black
-      language_version: python3
       args:
         - --diff
   - repo: https://gitlab.com/pycqa/flake8
@@ -11,7 +12,6 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear]
-        language_version: python3
         args:
           - --diff
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
+default_language_version:
+  python: python3.7
 repos:
   - repo: https://github.com/ambv/black
     rev: stable
     hooks:
     - id: black
-      language_version: python3
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.7
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear]
-        language_version: python3
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:


### PR DESCRIPTION
By fixing the python version to run the lint, and requiring everyone to have at least python 3.7, we can fix this issue: https://github.com/CodeChain-io/codechain-sdk-python/pull/42